### PR TITLE
ltopers - remove lto2filemaker

### DIFF
--- a/ltopers.rb
+++ b/ltopers.rb
@@ -13,7 +13,6 @@ class Ltopers < Formula
 
   def install
     bin.install "formatlto"
-    bin.install "lto2filemaker"
     bin.install "ltoperconfig"
     bin.install "mountlto"
     bin.install "writelto"

--- a/ltopers.rb
+++ b/ltopers.rb
@@ -13,7 +13,6 @@ class Ltopers < Formula
 
   def install
     bin.install "formatlto"
-    bin.install "ltoperconfig"
     bin.install "mountlto"
     bin.install "writelto"
     bin.install "renameschemas"


### PR DESCRIPTION
I don't use ltopers but I follow the project. It looks like lto2filemaker was removed but this is not reflected in the brew recipe.