### PR TITLE
Ffmprovisr

### DIFF
--- a/ffmprovisr.rb
+++ b/ffmprovisr.rb
@@ -5,7 +5,7 @@ class Ffmprovisr < Formula
   sha256 "4120fb650d35ab8fa8b96e6ec78740b3ade27249dd4193d858ffb1956a6098dc"
 
   def install
-  bin.install 'scripts/ffmprovisr'
-  prefix.install 'css', 'img', 'js', 'scripts', 'code_of_conduct.md', 'index.html', 'readme.md'
+    bin.install 'scripts/ffmprovisr'
+    prefix.install 'css', 'img', 'js', 'scripts', 'code_of_conduct.md', 'index.html', 'readme.md'
   end
 end

--- a/ffmprovisr.rb
+++ b/ffmprovisr.rb
@@ -1,5 +1,5 @@
 class Ffmprovisr < Formula
-  desc ""
+  desc "Repository of useful FFmpeg command lines for archivists"
   homepage "https://github.com/amiaopensource/ffmprovisr"
   url "https://github.com/amiaopensource/ffmprovisr/archive/v2017-05-05.tar.gz"
   sha256 "914952725bcf481174ffb1b7c2915eede7d2162de4e2c6d884faf4e10b8f93f8"

--- a/ffmprovisr.rb
+++ b/ffmprovisr.rb
@@ -1,0 +1,11 @@
+class Ffmprovisr < Formula
+  desc ""
+  homepage ""
+  url "https://github.com/amiaopensource/ffmprovisr/archive/v2017-04-19.tar.gz"
+  sha256 "4120fb650d35ab8fa8b96e6ec78740b3ade27249dd4193d858ffb1956a6098dc"
+
+  def install
+  bin.install 'scripts/ffmprovisr'
+  prefix.install 'css', 'img', 'js', 'scripts', 'code_of_conduct.md', 'index.html', 'readme.md'
+  end
+end

--- a/ffmprovisr.rb
+++ b/ffmprovisr.rb
@@ -1,6 +1,6 @@
 class Ffmprovisr < Formula
   desc ""
-  homepage ""
+  homepage "https://github.com/amiaopensource/ffmprovisr"
   url "https://github.com/amiaopensource/ffmprovisr/archive/v2017-05-05.tar.gz"
   sha256 "914952725bcf481174ffb1b7c2915eede7d2162de4e2c6d884faf4e10b8f93f8"
 

--- a/ffmprovisr.rb
+++ b/ffmprovisr.rb
@@ -1,8 +1,8 @@
 class Ffmprovisr < Formula
   desc ""
   homepage ""
-  url "https://github.com/amiaopensource/ffmprovisr/archive/v2017-04-19.tar.gz"
-  sha256 "4120fb650d35ab8fa8b96e6ec78740b3ade27249dd4193d858ffb1956a6098dc"
+  url "https://github.com/amiaopensource/ffmprovisr/archive/v2017-05-05.tar.gz"
+  sha256 "914952725bcf481174ffb1b7c2915eede7d2162de4e2c6d884faf4e10b8f93f8"
 
   def install
     bin.install 'scripts/ffmprovisr'

--- a/ffmprovisr.rb
+++ b/ffmprovisr.rb
@@ -5,7 +5,7 @@ class Ffmprovisr < Formula
   sha256 "914952725bcf481174ffb1b7c2915eede7d2162de4e2c6d884faf4e10b8f93f8"
 
   def install
-    bin.install 'scripts/ffmprovisr'
-    prefix.install 'css', 'img', 'js', 'scripts', 'code_of_conduct.md', 'index.html', 'readme.md'
+    bin.install "scripts/ffmprovisr"
+    prefix.install "css", "img", "js", "scripts", "code_of_conduct.md", "index.html", "readme.md"
   end
 end


### PR DESCRIPTION
Partially addresses https://github.com/amiaopensource/ffmprovisr/issues/150

Downloads ffmprovisr to homebrew cellar and path installs script from https://github.com/amiaopensource/ffmprovisr/pull/181 to allow terminal shortcut