### PR TITLE
QCTools formula

### DIFF
--- a/qctools.rb
+++ b/qctools.rb
@@ -9,7 +9,6 @@ class Qctools < Formula
   depends_on "pkg-config" => :build
   depends_on "amiaopensource/amiaos/qwt-qt5"
   depends_on "qt"
-  depends_on "freetype"
   depends_on "ffmpeg" => ["with-freetype"]
 
   def install

--- a/qctools.rb
+++ b/qctools.rb
@@ -4,7 +4,7 @@ class Qctools < Formula
   url "https://github.com/bavc/qctools/archive/v0.8.tar.gz"
   sha256 "5362dc8325aeb37e0742a5e5df7b831e7fe82a7b06c72c50463a43a7ad0b56bc"
   head "https://github.com/bavc/qctools.git"
-  revision 2
+  revision 3
 
   depends_on "pkg-config" => :build
   depends_on "amiaopensource/amiaos/qwt-qt5"
@@ -14,18 +14,15 @@ class Qctools < Formula
 
   def install
     ENV["QCTOOLS_USE_BREW"]="true"
-    path = ENV["PATH"]
-    ENV["PATH"] = "#{path}:#{HOMEBREW_PREFIX}/bin"
 
-    cd "Project/QtCreator" do
-      cd "qctools-lib"
+    cd "Project/QtCreator/qctools-lib" do
       system "qmake", "qctools-lib.pro"
       system "make"
-      cd "../qctools-gui"
+    end
+    cd "Project/QtCreator/qctools-gui" do
       system "qmake", "qctools-gui.pro"
       system "make"
-      cd ".."
-      prefix.install "qctools-gui/QCTools.app"
+      prefix.install "QCTools.app"
     end
   end
 end


### PR DESCRIPTION
In my opinion:
- the `ENV["PATH"]` part is not used
- the `cd` commands can be simplified

I also have a doubt, that the `depends_on "freetype"` line is necessary, because there is already `depends_on "ffmpeg" => ["with-freetype"]`.