### PR TITLE
set to keg_only

### DIFF
--- a/ffmpegdecklink.rb
+++ b/ffmpegdecklink.rb
@@ -4,6 +4,7 @@ class Ffmpegdecklink < Formula
   url "https://ffmpeg.org/releases/ffmpeg-3.4.tar.bz2"
   sha256 "5d8911fe6017d00c98a359d7c8e7818e48f2c0cc2c9086a986ea8cb4d478c85e"
   head "https://github.com/FFmpeg/FFmpeg.git"
+  keg_only 'Anything that needs this will know where to look'
 
   option "with-chromaprint", "Enable the Chromaprint audio fingerprinting library"
   option "with-fdk-aac", "Enable the Fraunhofer FDK AAC library"


### PR DESCRIPTION
I've been getting some issues with having two ffmpeg library sets installed. I suggest that we use this formula as keg-only and direct scripts to use something like:

```
FFMPEG_DECKLINK=($(brew --prefix ffmpegdecklink)/bin/ffmpeg-dl)
FFPLAY_DECKLINK=($(brew --prefix ffmpegdecklink)/bin/ffplay-dl)
```