### PR TITLE
ffmpeg: update to 3.4.2 & avoid opportunistic linkage to jack

### DIFF
--- a/ffmpegdecklink.rb
+++ b/ffmpegdecklink.rb
@@ -1,9 +1,8 @@
 class Ffmpegdecklink < Formula
   desc "FFmpeg with --enable-decklink"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-3.4.1.tar.bz2"
-  sha256 "f3443e20154a590ab8a9eef7bc951e8731425efc75b44ff4bee31d8a7a574a2c"
-  revision 3
+  url "https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2"
+  sha256 "eb0370bf223809b9ebb359fed5318f826ac038ce77933b3afd55ab1a0a21785a"
   head "https://github.com/FFmpeg/FFmpeg.git"
   keg_only "anything that needs this will know where to look"
 

--- a/ffmpegdecklink.rb
+++ b/ffmpegdecklink.rb
@@ -3,7 +3,7 @@ class Ffmpegdecklink < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-3.4.1.tar.bz2"
   sha256 "f3443e20154a590ab8a9eef7bc951e8731425efc75b44ff4bee31d8a7a574a2c"
-  revision 2
+  revision 3
   head "https://github.com/FFmpeg/FFmpeg.git"
   keg_only "anything that needs this will know where to look"
 
@@ -95,6 +95,7 @@ class Ffmpegdecklink < Formula
       --enable-version3
       --enable-hardcoded-tables
       --enable-avresample
+      --disable-jack
       --cc=#{ENV.cc}
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}


### PR DESCRIPTION
As has been done for the regular FFmpeg in https://github.com/Homebrew/homebrew-core/commit/894ef0a9ce8757b6746afa5035f11d916f87cb9f.