### PR TITLE
Audiorecorder2

### DIFF
--- a/audiorecorder.rb
+++ b/audiorecorder.rb
@@ -4,6 +4,8 @@ class Audiorecorder < Formula
   url "https://github.com/amiaopensource/audiorecorder/archive/0.1.09.tar.gz"
   sha256 "d244888d5b569a84e541d86a4e8141bd0dec59435a1b815643a2ae15bc87c722"
   head "https://github.com/amiaopensource/audiorecorder.git"
+  
+  option "with-audiorecorder2"
 
   depends_on "sdl"
   depends_on "ffmpeg" => ["with-sdl2", "with-freetype"]
@@ -15,6 +17,12 @@ class Audiorecorder < Formula
   def install
     bin.install "audiorecorder"
     man1.install "audiorecorder.1"
+    
+    if build.with?("audiorecorder2")
+      if RUBY_PLATFORM.include?('linux')
+        bin.install "Linux/audiorecorder2"
+      end
+    end
   end
 
   def post_install

--- a/audiorecorder.rb
+++ b/audiorecorder.rb
@@ -21,6 +21,10 @@ class Audiorecorder < Formula
     if build.with?("audiorecorder2")
       if RUBY_PLATFORM.include?('linux')
         bin.install "Linux/audiorecorder2"
+      elsif
+        RUBY_PLATFORM.include?('darwin')
+        prefix.install "macOS/audiorecorder2-osx.tgz"
+        system("open #{prefix}/audiorecorder2-osx.tgz")
       end
     end
   end

--- a/audiorecorder.rb
+++ b/audiorecorder.rb
@@ -1,8 +1,8 @@
 class Audiorecorder < Formula
   desc "Tool for calibration and recording of analog audio sources"
   homepage "https://github.com/amiaopensource/audiorecorder"
-  url "https://github.com/amiaopensource/audiorecorder/archive/0.1.09.tar.gz"
-  sha256 "d244888d5b569a84e541d86a4e8141bd0dec59435a1b815643a2ae15bc87c722"
+  url "https://github.com/amiaopensource/audiorecorder/archive/2018-08-17.tar.gz"
+  sha256 "2c784b7dc70faf6befb5602ae61ee119bcceee8ad7db90d9ca891af423d9d617"
   head "https://github.com/amiaopensource/audiorecorder.git"
   
   option "with-audiorecorder2"


### PR DESCRIPTION
added option to install audiorecorder2 with tag `--with-audiorecorder2`

In Linux this will install to path and can be run via `audiorecorder2`

In macOS, audiorecorder2 will be built, and the containing folder is opened so that user can drag app to desired location.

Tested on my end for both systems and install was working!