### PR TITLE
delete redundant option

### DIFF
--- a/audiorecorder.rb
+++ b/audiorecorder.rb
@@ -10,7 +10,7 @@ class Audiorecorder < Formula
   option "with-audiorecorder2"
 
   depends_on "sdl"
-  depends_on "ffmpeg" => ["with-sdl2", "with-freetype"]
+  depends_on "ffmpeg" => ["with-freetype"]
   depends_on "mpv"
   depends_on "sox"
   depends_on "dialog"


### PR DESCRIPTION
Since FFmpeg version 4.0 or 4.1 (sorry, I don’t remember) the `--with-sdl2` option is set by default.