### PR TITLE
ffmpegdecklink: delete unneeded code

### DIFF
--- a/ffmpegdecklink.rb
+++ b/ffmpegdecklink.rb
@@ -138,10 +138,6 @@ class Ffmpegdecklink < Formula
     args << "--extra-cflags=-I#{HOMEBREW_PREFIX}/include"
     args << "--extra-ldflags=-L#{HOMEBREW_PREFIX}/include"
 
-    # These librares are GPL-incompatible, and require ffmpeg be built with
-    # the "--enable-nonfree" flag, which produces unredistributable libraries
-    args << "--enable-nonfree" if build.with?("fdk-aac") || build.with?("openssl")
-
     system "./configure", *args
 
     system "make"


### PR DESCRIPTION
`--enable-nonfree` is always passed at [line 136](https://github.com/amiaopensource/homebrew-amiaos/blob/0c54269b8f656d3f326f94ec4271b24bd0aac890/ffmpegdecklink.rb#L136)