### PR TITLE
use Homebrew’s mpv

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Homebrew tap for AMIA Open Source formulae:
 - **gtkdialog** — A small utility for fast and easy GUI building. Note that gtkdialog is used by vrecord.
 - **LTOpers** — Scripts for doing stuff with LTFS.
 - **mkvparse** — A simple Matroska (MKV) parser.
-- **mpv** — A cross platform media player (forked from https://github.com/mpv-player/mpv)
 - **pbprotracktor** — Make postgres calls to public broadcasting scheduling databases to produce a PBCore XML output.
 - **vrecord** — Open-source software for capturing a video signal and turning it into a digital file.
 
@@ -67,3 +66,5 @@ These projects are no longer developed nor maintaied. Yet please feel free to re
 
 - **digibase** — Uses MySQL to create a database which tracks tapes through a digitization workflow, designed to work with vrecord and [mediamicroservices](https://github.com/mediamicroservices).
 - **lenticular** — Digital restoration of lenticular colours from greyscale digitisations.
+- **mpv** — A cross platform media player (forked from https://github.com/mpv-player/mpv)
+

--- a/vrecord.rb
+++ b/vrecord.rb
@@ -4,7 +4,7 @@ class Vrecord < Formula
   url "https://github.com/amiaopensource/vrecord/archive/v2019-07-22.tar.gz"
   version "2019-07-22"
   sha256 "534e9daff42c95e300969e840b278a91ada3db739220bf67bd989834298bd11c"
-  revision 2
+  revision 3
   head "https://github.com/amiaopensource/vrecord.git"
 
   bottle :unneeded
@@ -12,12 +12,12 @@ class Vrecord < Formula
   depends_on "amiaopensource/amiaos/decklinksdk"
   depends_on "amiaopensource/amiaos/ffmpegdecklink"
   depends_on "amiaopensource/amiaos/gtkdialog"
-  depends_on "amiaopensource/amiaos/mpv"
   depends_on "cowsay"
   depends_on "freetype"
   depends_on "gnuplot"
   depends_on "mediaconch"
   depends_on "mkvtoolnix"
+  depends_on "mpv"
   depends_on "qcli"
   depends_on "sdl"
   depends_on "xmlstarlet"


### PR DESCRIPTION
resolves https://github.com/amiaopensource/homebrew-amiaos/issues/209

Homebrew includes again an `mpv` formula. This considers `mpv 0.30.0` which is compatible with the current `ffmpeg`.