### PR TITLE
[WIP] initial ltfs formula

### DIFF
--- a/ltfs.rb
+++ b/ltfs.rb
@@ -1,0 +1,26 @@
+class Ltfs < Formula
+  desc "Reference implementation of the LTFS format Spec for stand alone tape drive"
+  homepage "https://github.com/LinearTapeFileSystem/ltfs"
+  url "https://github.com/LinearTapeFileSystem/ltfs/archive/v2.4.1.2-10254.tar.gz"
+  sha256 "ddd4032190c15ebd4aa30d3df075e1d0a06e4fba78a598032b2805fe138b9ad3"
+  head "https://github.com/LinearTapeFileSystem/ltfs.git"
+
+  depends_on "automake"
+  depends_on "autoconf"
+  depends_on "gnu-sed"
+  depends_on "icu4c"
+  depends_on "libtool"
+  depends_on "libxml2" => :build
+  depends_on "ossp-uuid"
+  depends_on "pkg-config" => :build
+  depends_on :osxfuse
+
+  def install
+    system "./autogen.sh"
+    ENV.append "LDFLAGS", "-framework CoreFoundation"
+    ENV.append "LDFLAGS", "-framework IOKit"
+    system "./configure", "--disable-snmp", "LDFLAGS=#{ENV.ldflags}"
+    system "make"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
This is a work in progress as currently the installer fails with this output:

```
brew install ltfs.rb 
==> Downloading https://github.com/LinearTapeFileSystem/ltfs/archive/v2.4.1.2-10254.tar.gz
Already downloaded: /Users/daverice/Library/Caches/Homebrew/downloads/7e483200a26863147c9d69fb54798533d5b1755cb95722eb8817fd5bdbf651ca--ltfs-2.4.1.2-10254.tar.gz
==> ./autogen.sh
==> ./configure --disable-snmp LDFLAGS=-framework CoreFoundation -framework IOKit
==> make
==> make install
Last 15 lines from /Users/daverice/Library/Logs/Homebrew/ltfs/04.make:
		mkdir -p "/usr/local/share/snmp"; \
		cp LtfsSnmpTrapDef.txt LTFS-MIB.txt "/usr/local/share/snmp/"; \
	elif [ ! -f "/usr/local/share/snmp/LtfsSnmpTrapDef.txt" ]; then \
		cp LtfsSnmpTrapDef.txt "/usr/local/share/snmp/LtfsSnmpTrapDef.txt"; \
	elif [ ! -f "/usr/local/share/snmp/LTFS-MIB.txt" ]; then \
		cp LTFS-MIB.txt "/usr/local/share/snmp/LTFS-MIB.txt"; \
	fi
 ../../build-aux/install-sh -c -d '/usr/local/lib'
 /bin/sh ../../libtool   --mode=install /usr/bin/install -c   libltfs.la '/usr/local/lib'
libtool: install: /usr/bin/install -c .libs/libltfs.0.dylib /usr/local/lib/libltfs.0.dylib
install: /usr/local/lib/libltfs.0.dylib: Operation not permitted
make[3]: *** [install-libLTLIBRARIES] Error 71
make[2]: *** [install-am] Error 2
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1

Do not report this issue to Homebrew/brew or Homebrew/core!
```
Related info at https://github.com/LinearTapeFileSystem/ltfs/blob/master/README.md