### PR TITLE
update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,7 @@ We encourage the writing of portable code. Often only little additional work is 
 
 We encourage the use of either:
 
-- date-based versioning i.e. the `YYYY-MM-DD` format (e.g. `v2017-02-18` or `2020-04-05`)
-- [semantic versioning](http://semver.org/) i.e. the `major.minor.patch` format (e.g. `v1.17.2` or `2.0.7`)
+- date-based versioning i.e. the `YYYY-MM-DD` format (e.g. `2020-04-05`)
+- [semantic versioning](https://semver.org/) i.e. the `major.minor.patch` format (e.g. `2.0.7`)
 
 for the releases.
-
-## Hints
-
-- If you choose date-based versioning, then you may add a line such as `version "2017-07-22"`. Note that this is not needed for semantic versioning.
-- If you do not need to compile the code, then you may add the line `bottle :unneeded`.


### PR DESCRIPTION
- delete hints (`bottle :unneeded` is no longer useful)
- use `https://` rather than `http://`
- naming `script-version` is scanned automatically