### PR TITLE
ffmpegdecklink: align to the canonical Homebrew formula

### DIFF
--- a/ffmpegdecklink.rb
+++ b/ffmpegdecklink.rb
@@ -3,13 +3,14 @@ class Ffmpegdecklink < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.3.1.tar.xz"
   sha256 "ad009240d46e307b4e03a213a0f49c11b650e445b1f8be0dda2a9212b34d2ffb"
+  revision 1
   head "https://github.com/FFmpeg/FFmpeg.git"
   keg_only "anything that needs this will know where to look"
 
   option "with-iec61883", "Enable DV device (Linux)" if OS.linux?
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
-  depends_on "texi2html" => :build
+  depends_on "texinfo" => :build
 
   depends_on "amiaopensource/amiaos/decklinksdk"
   depends_on "fontconfig"


### PR DESCRIPTION
- remove `texi2html`
- add `texinfo`