### PR TITLE
put Windows Terminal first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Cross-Platform Software
 
-We encourage the writing of portable code. Often only little additional work is needed to allow the installation using Homebrew not only on _macOS_ but also on a variety of _Linux_ distributions. This has a wonderful side effect: people using the _Windows_ Subsystem for Linux or Terminal can easily install, use and update our software as well.
+We encourage the writing of portable code. Often only little additional work is needed to allow the installation using Homebrew not only on **macOS** but also on a variety of **Linux** distributions. This has a wonderful side effect: people using the **Windows** Terminal or Subsystem for Linux (WSL) can easily install, use and update our software as well.
 
 ## Versioning
 


### PR DESCRIPTION
Since some time now, on the Windows `Terminal` app one can use the same commands than on macOS or Linux.