### PR TITLE
vrecord: add revision

### DIFF
--- a/vrecord.rb
+++ b/vrecord.rb
@@ -4,6 +4,7 @@ class Vrecord < Formula
   url "https://github.com/amiaopensource/vrecord/archive/v2021-01-25.tar.gz"
   version "2021-01-25"
   sha256 "2e62563e71f98ca4eb33bb2989989c9ccdb8085fe1292eacf4c7efd9e4112589"
+  revision 1
   head "https://github.com/amiaopensource/vrecord.git"
 
   depends_on "amiaopensource/amiaos/deckcontrol"


### PR DESCRIPTION
Bump, in order to make sure the last `ffmpegdecklink` is used. See https://github.com/amiaopensource/vrecord/issues/669.