### PR TITLE
deckcontrol v0.5

### DIFF
--- a/deckcontrol.rb
+++ b/deckcontrol.rb
@@ -1,15 +1,14 @@
 class Deckcontrol < Formula
   desc "Control an attached videodeck via Blackmagic Design Decklink SDK"
   homepage "https://github.com/bavc/deckcontrol"
-  url "https://github.com/bavc/deckcontrol/archive/v0.4.tar.gz"
-  sha256 "511b71f139f045e78ca084ed3997a73c6a1c34ae0c02126e657c4120097974fa"
-  revision 1
+  url "https://github.com/bavc/deckcontrol/archive/v0.5.tar.gz"
+  sha256 "73abcbb1801b11aaf954567fe8f86edd2efbe789037774653de6f06b219d48e7"
   head "https://github.com/bavc/deckcontrol.git"
 
   depends_on "amiaopensource/amiaos/decklinksdk" => :build
 
   def install
-    system "make"
+    system "make", "BMSDK=#{Formula["decklinksdk"].opt_include}"
     bin.install "deckcontrol"
   end
 end


### PR DESCRIPTION
@privatezero please test via linuxbrew. As homebrew moved from /usr/local to /opt/homebrew the hardcoded include path for mac broke and this caused many vrecord installs to fail at this dependency (such as @bturkus at https://github.com/amiaopensource/vrecord/issues/673#issue-926477737). This update moves the BMSDK path to a Make variable so the homebrew installer can guess where it is rather than the Makefile.