### PR TITLE
vrecord: upgrade gtkdialog

### DIFF
--- a/vrecord.rb
+++ b/vrecord.rb
@@ -4,12 +4,12 @@ class Vrecord < Formula
   url "https://github.com/amiaopensource/vrecord/archive/refs/tags/v2023-03-01.tar.gz"
   version "2023-03-01"
   sha256 "d7a6de526f8cf992a24e1456d3935b3a938e5f8220abc09c722a1da9608e8e5e"
-  revision 1
+  revision 2
   head "https://github.com/amiaopensource/vrecord.git"
 
   depends_on "amiaopensource/amiaos/ffmpegdecklink"
-  depends_on "amiaopensource/amiaos/gtkdialog"
   depends_on "cowsay"
+  depends_on "gtkdialog"
 
   on_macos do
     depends_on "amiaopensource/amiaos/deckcontrol"


### PR DESCRIPTION
Works on my end on macOS 12.6.5 with AArch64 (Apple M1).