### PR TITLE
Update gtkdialog to 0.8.5e

### DIFF
--- a/gtkdialog.rb
+++ b/gtkdialog.rb
@@ -1,9 +1,8 @@
 class Gtkdialog < Formula
   desc "Small utility for fast and easy GUI building"
   homepage "https://code.google.com/archive/p/gtkdialog/"
-  url "https://github.com/puppylinux-woof-CE/gtkdialog/archive/refs/tags/0.8.4d.tar.gz"
-  sha256 "1d3619ef1aca2baa783b936e8c6bd67135621f47428049c8231db9ee366f73db"
-  revision 6
+  url "https://github.com/puppylinux-woof-CE/gtkdialog/archive/refs/tags/0.8.5e.tar.gz"
+  sha256 "93561ed4042c113b85aa5550f51ae4e6980a5de6e083db5c358d6fc2fb2feb0a"
 
   depends_on "at-spi2-core" => :build
   depends_on "autoconf" => :build


### PR DESCRIPTION
This seems needed to keep things happy on Linux (Ubuntu) - does this update work on the Mac side of things?