### PR TITLE
gtkdialog 0.8.5e

### DIFF
--- a/gtkdialog.rb
+++ b/gtkdialog.rb
@@ -36,7 +36,7 @@ class Gtkdialog < Formula
   depends_on "gtk+"
 
   def install
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" # Workaround for Xcode 14.3.
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" # Workaround for Xcode >= 14.3.
     system "./autogen.sh"
     system "make"
     bin.install "src/gtkdialog"


### PR DESCRIPTION
Tested on macOS 26.1 and 15.7.2, as well as on Debian 13.1 and Ubuntu 24.04.3 LTS.