### PR TITLE
Update TROUBLESHOOTING.md

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,11 +2,14 @@
 
 ## vrecord
 
-#### ffmpegdecklink & ffmpeg-ma error : atomic
-Some macOS users have been unable to compile vrecord's FFmpeg dependencies  with the error:
+### [macOS] ffmpegdecklink & ffmpeg-ma error : atomic
+
+Some macOS users have been unable to compile vrecord's FFmpeg dependencies with the error:
+
 ```
 fatal error: 'atomic' file not found
 ```
+
 A resolution was reported [here](https://github.com/amiaopensource/vrecord/issues/852#issuecomment-2701891440) of fully reinstalling Command Line Tools with the commands:
 
 ```
@@ -14,11 +17,14 @@ sudo rm -rfv /Library/Developer/CommandLineTools
 xcode-select --install
 ```
 
-#### ffmpegdecklink error : libiec61883
+### [Ubuntu] ffmpegdecklink error : libiec61883
+
 Sometimes Ubuntu users experience the error:
+
 ```
 ERROR: libiec61883 not found
 ```
+
 A resolution for this was reported in [this issue](https://github.com/amiaopensource/homebrew-amiaos/issues/335) of running:
 
 ```
@@ -34,15 +40,18 @@ eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv) \
   brew install ffmpegdecklink --with-iec61883
 ```
 
-#### ffmpegdecklink error : fontconfig
+### [Ubuntu] ffmpegdecklink error : fontconfig
 
 Some Ubuntu users have reported an issue with being unable to install ffmpegdecklink with the following error:
+
 ```
 ERROR: fontconfig not found using pkg-config
 ```
+
 This was found to be resolved by running `brew reinstall bzip2 && brew reinstall fontconfig` and then again installing ffmpegdecklink.
 
-#### Gtkdialog error (Mac)
+### [macOS] gtkdialog error
+
 Some users of macOS post version 13 have had issues installing gtkdialog with an error similar to:
 
 ```
@@ -51,6 +60,7 @@ make[2]: *** [gtkdialog.info] Error 127
 make[1]: *** [all-recursive] Error 1
 make: *** [all] Error 2
 ```
+
 where the gtkdialog build script is unable to find the makeinfo dependency.
 
 A successful work around has been found to be installing gtkdialog by running:
@@ -60,9 +70,10 @@ ln -sf "$(which makeinfo)" "$(brew --prefix)/Homebrew/Library/Homebrew/shims/mac
 brew install gtkdialog
 ```
 
+### [Ubuntu] gtkdialog error
 
-#### Gtkdialog error (Ubuntu)
 Sometimes Ubuntu users experience the error:
+
 ```
 Makefile:338: recipe for target 'gtkdialog.info' failed
 make[2]: *** [gtkdialog.info] Error 127
@@ -73,39 +84,16 @@ make[1]: Leaving directory '/tmp/gtkdialog-20220607-22530-9bc217/gtkdialog-0.8.4
 Makefile:363: recipe for target 'all' failed
 make: *** [all] Error 2
 ```
-which can be resolved by reinstalling `texinfo`:
+
+which can be resolved by reinstalling texinfo:
+
 ```
 sudo apt-get install --reinstall texinfo
 brew install gtkdialog
 ```
+
 before running:
+
 ```
 brew install vrecord
-```
-
-## mpv
-
-Sometimes users experience the error:
-```
-dyld: Library not loaded: @rpath/libswiftAppKit.dylib  
-  Referenced from: /usr/local/bin/mpv  
-  Reason: image not found  
-Abort trap: 6
-```
-which can be resolved by reinstalling `mpv` from source.
-
-### When Xcode 10.1 or newer is installed
-
-Run the command:
-```
-brew reinstall --build-from-source mpv
-```
-
-### When Xcode 10.1 or newer is not installed
-
-There is still a local AMIA open source tap of `mpv` that should work if you don’t want to install Xcode.
-
-Uninstall or unlink the current mpv build and then run:
-```
-brew install amiaopensource/amiaos/mpv
 ```


### PR DESCRIPTION
- standardise the style throughout the document
- specify everywhere which operating system this refers to
- remove the `mpv` section, since the information refers to `Xcode` version 10, which was current between September 2018 and September 2019 (furthermore, we no longer maintain an `mpv` fork here)