### PR TITLE
vrecord: move mediaarea dependencies

### DIFF
--- a/vrecord.rb
+++ b/vrecord.rb
@@ -3,21 +3,21 @@ class Vrecord < Formula
   homepage "https://github.com/amiaopensource/vrecord"
   url "https://github.com/amiaopensource/vrecord/archive/refs/tags/vrecord_v2026-03-03.tar.gz"
   sha256 "fc615a551ffdd8cba78ab0ea1e3913bc37532e8260604a3ce5c28098ac174c92"
-  revision 1
+  revision 2
   head "https://github.com/amiaopensource/vrecord.git", branch: "main"
 
   depends_on "amiaopensource/amiaos/gtkdialog"
   depends_on "cowsay"
   depends_on "mediaarea/mediaarea/ffmpeg-ma"
   depends_on "mediaarea/mediaarea/timecodexml"
+  depends_on "mediaconch"
+  depends_on "mediainfo"
 
   on_macos do
     depends_on "amiaopensource/amiaos/deckcontrol"
     depends_on "bash"
     depends_on "gnuplot" if MacOS.version >= :mojave
     depends_on "mediaarea/mediaarea/dvrescue"
-    depends_on "mediaconch"
-    depends_on "mediainfo"
     depends_on "mkvtoolnix" if MacOS.version >= :mojave
     depends_on "mpv" if MacOS.version >= :mojave
     depends_on "qcli" if MacOS.version >= :mojave
@@ -46,9 +46,7 @@ class Vrecord < Formula
         ** IMPORTANT FOR LINUX INSTALL **
         Additional install steps are necessary for a fully functioning Vrecord
         install on Linux. This includes using the standard package manager to
-        install gnuplot, xmlstarlet, mkvtoolnix and mediaconch. Additionally,
-        it often is necessary to remove the Homebrew installed version of SDL2
-        to prevent conflicts. For more information please see:
+        install gnuplot, xmlstarlet, and mkvtoolnix. For more information please see:
         https://github.com/amiaopensource/vrecord/blob/master/Resources/Documentation/linux_installation.md
       EOS
     end


### PR DESCRIPTION
I think at this point we can move mediaconch and mediainfo into the common dependencies. Please test and make sure this works on someone else's build as well though!