### PR TITLE
vrecord: qcli as linux dependency

### DIFF
--- a/vrecord.rb
+++ b/vrecord.rb
@@ -3,7 +3,7 @@ class Vrecord < Formula
   homepage "https://github.com/amiaopensource/vrecord"
   url "https://github.com/amiaopensource/vrecord/archive/refs/tags/vrecord_v2026-03-03.tar.gz"
   sha256 "fc615a551ffdd8cba78ab0ea1e3913bc37532e8260604a3ce5c28098ac174c92"
-  revision 1
+  revision 2
   head "https://github.com/amiaopensource/vrecord.git", branch: "main"
 
   depends_on "amiaopensource/amiaos/gtkdialog"
@@ -41,14 +41,12 @@ class Vrecord < Formula
   end
 
   on_linux do
+    depends_on "qcli"
     def caveats
       <<~EOS
         ** IMPORTANT FOR LINUX INSTALL **
-        Additional install steps are necessary for a fully functioning Vrecord
-        install on Linux. This includes using the standard package manager to
-        install gnuplot, xmlstarlet, mkvtoolnix and mediaconch. Additionally,
-        it often is necessary to remove the Homebrew installed version of SDL2
-        to prevent conflicts. For more information please see:
+        Additional install steps may be necessary for a fully functioning Vrecord
+        install on Linux, particularly for some optional dependencies. For more information please see:
         https://github.com/amiaopensource/vrecord/blob/master/Resources/Documentation/linux_installation.md
       EOS
     end


### PR DESCRIPTION
Things seem to work with the brew installed qcli, so adding to linux dependencies (and simplified some post install language)